### PR TITLE
Fix typo and errors in Kurdish Unicode characters

### DIFF
--- a/NumberToKurdishWords/Extensions/Conversion.cs
+++ b/NumberToKurdishWords/Extensions/Conversion.cs
@@ -10,7 +10,7 @@ namespace NumberToKurdishWords.Extensions
             var isNumber = long.TryParse(val.ToString(), out var  number);
             if (!isNumber)
             {
-                return "ته‌نها پشتگیری ژماره‌ ده‌كات.";
+                return "تەنها پشتگیری ژمارە دەکات.";
             }
             var realNumber = number;
             switch (number)
@@ -24,7 +24,7 @@ namespace NumberToKurdishWords.Extensions
             var words = " ";
             if (realNumber> 999999999999999)
             {
-                return "پشتگیری ژماره‌ بەرزتر لە تریلیۆن ناكات"; // doesn't support numbers above one trillion
+                return "پشتگیری ژمارە بەرزتر لە تریلیۆن ناکات"; // doesn't support numbers above one trillion
             }
 
 
@@ -49,7 +49,7 @@ namespace NumberToKurdishWords.Extensions
 
             if ((number / 1000) > 0)
             {
-                    words += ToKurdishText(number / 1000) + " هه‌زار  ";
+                    words += ToKurdishText(number / 1000) + " هەزار  ";
 
                     number %= 1000;
             }
@@ -57,7 +57,7 @@ namespace NumberToKurdishWords.Extensions
 
             if ((number / 100) > 0)
             {
-                words += ToKurdishText(number / 100) + " سه‌د ";
+                words += ToKurdishText(number / 100) + " سەد ";
                 number %= 100;
             }
 
@@ -66,8 +66,8 @@ namespace NumberToKurdishWords.Extensions
                 if (words != " ")
                     words += " و ";
 
-                var unitsMap = new[] { "سفر", "یه‌ك", "دوو", "سێ", "چوار", "پێنج", "شه‌ش", "حه‌وت", "هه‌شت", "نۆ", "ده‌", "یازده‌", "دوازده‌", "سێزده‌", "چوارده‌", "پازده‌", "شازده‌", "حه‌ڤده‌", "هه‌ژده‌", "نۆزده‌" };
-                var tensMap = new[] { "سفر", "ده‌", "بیست", "سی", "چل", "په‌نجا", "شه‌ست", "حه‌فتا", "هه‌شتا", "نۆوه‌ت" };
+                var unitsMap = new[] { "سفر", "یەک", "دوو", "سێ", "چوار", "پێنج", "شەش", "حەوت", "هەشت", "نۆ", "دە", "یازدە", "دوازدە", "سێزدە", "چواردە", "پازدە", "شازدە", "حەڤدە", "هەژدە", "نۆزدە" };
+                var tensMap = new[] { "سفر", "دە", "بیست", "سی", "چل", "پەنجا", "شەست", "حەفتا", "هەشتا", "نەوەد" };
 
                 if (number < 20)
                     words += unitsMap[number];
@@ -82,17 +82,17 @@ namespace NumberToKurdishWords.Extensions
             }
 
 
-            words = words.Replace("یه‌ك سه‌د", "سه‌د");
+            words = words.Replace("یەک سەد", "سەد");
 
-            words = words.Replace("یه‌ك ملیۆن", "ملیۆنێك");
-            words = words.Replace("سه‌د و ملیۆنێك", "سه‌د و یه‌ك ملیۆن");
+            words = words.Replace("یەک ملیۆن", "ملیۆنێک");
+            words = words.Replace("سەد و ملیۆنێک", "سەد و یەک ملیۆن");
 
 
-            words = words.Replace("یه‌ك ملیار", "ملیارێك");
-            words = words.Replace("سه‌د و ملیارێك", "سه‌د و یه‌ك ملیار");
+            words = words.Replace("یەک ملیار", "ملیارێک");
+            words = words.Replace("سەد و ملیارێک", "سەد و یەک ملیار");
 
-            words = words.Replace("یه‌ك تریلیۆن", "تریلیۆنێك");
-            words = words.Replace("سه‌د و تریلیۆنێك", "سه‌د و یه‌ك تریلیۆن");
+            words = words.Replace("یەک تریلیۆن", "تریلیۆنێک");
+            words = words.Replace("سەد و تریلیۆنێک", "سەد و یەک تریلیۆن");
             words = words.Replace("  ", " ");
             return words;
 

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ converting any number type for tex.
 the result is 
 
 ```
- سه‌د و یه‌ك هه‌زار  دوو سه‌د و بیست و یه‌ك
+ سەد و یەک هەزار  دوو سەد و بیست و یەک
 ```


### PR DESCRIPTION
In CKB Kurdish we do not use `[(U+0647) + (U+200C)]` for `(U+06D5)`.
Also `(U+0643)` is not a Kurdish character and we use `(U+06A9)` instead.
Thanks for your work!